### PR TITLE
Bumped TRS operator chart version for trs operator new version.

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,12 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.1] - 2022-01-11
+
+### Changed
+
+- TRS operator code now uses v2 of hms-trs-kafkalib.  No functional changes were made.
+
 ## [2.0.0] - 2021-11-19
 
 ### Changed

--- a/charts/v2.0/cray-hms-trs-operator/Chart.yaml
+++ b/charts/v2.0/cray-hms-trs-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cray-hms-trs-operator
-version: 2.0.0
+version: 2.0.1
 description: Cray HMS TRS Operator
 home: "https://github.com/Cray-HPE/hms-trs-operator-charts"
 sources:
@@ -8,6 +8,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.0.0"
+appVersion: "2.0.1"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-trs-operator/values.yaml
+++ b/charts/v2.0/cray-hms-trs-operator/values.yaml
@@ -1,5 +1,5 @@
 global:
-  appVersion: 2.0.0
+  appVersion: 2.0.1
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-trs-operator

--- a/cray-hms-trs-operator.compatibility.yaml
+++ b/cray-hms-trs-operator.compatibility.yaml
@@ -10,6 +10,7 @@ chartVersionToCSMVersion:
 chartVersionToApplicationVersion:
   # Chart version: Application version
   "2.0.0": "2.0.0"
+  "2.0.1": "2.0.1"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION
### Summary and Scope

The TRS operator recently had a PR to bring it up to date with
the latest TRS Go packages.  This requires a Helm chart version
bump as well.

DOES THIS CHANGE INVOLVE ANY SCHEME CHANGES?  N

REMINDER: HAVE YOU INCREMENTED VERSION NUMBERS? E.G., .spec, Chart.yaml Y

REMINDER 2: HAVE YOU UPDATED THE COPYRIGHT PER hpe GUIDELINES: © Copyright 2014-2020 Hewlett Packard Enterprise Development LP    ? Y

### Issues and Related PRs

* Partially resolves CASMHMS-3088

### Testing

Tested on:

* baldar

Was a fresh Install tested? N   Not currently using this operator.
Was an Upgrade tested?      Y
Was a Downgrade tested?     Y
Was a CT test run?          N   CT tests don't interact with this operator.
If schema changes were part of this change, how were those handled in your upgrade/downgrade testing? N/A

New chart was fetched from GitHub.  It was deployed, and TRS worker
startup was verified.

### Risks and Mitigations

Low risk, no change to chart functionality, plus the TRS operator is not currently used.

