### PR TITLE
Changed version to 2.0.3 and appversion to 2.1.0

### DIFF
--- a/changelog/v2.0.md
+++ b/changelog/v2.0.md
@@ -5,6 +5,18 @@ All notable changes to this project for v2.0.Z will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.3] - 2022-07-12
+
+### Changed
+
+- TRS operator now uses version v1beta2 of kafka.strimzi.io
+
+## [2.0.2] - 2022-05-06
+
+### Changed
+
+- Changed to build using github actions
+
 ## [2.0.1] - 2022-01-11
 
 ### Changed

--- a/charts/v2.0/cray-hms-trs-operator/Chart.yaml
+++ b/charts/v2.0/cray-hms-trs-operator/Chart.yaml
@@ -23,7 +23,7 @@
 #
 apiVersion: v2
 name: cray-hms-trs-operator
-version: 2.0.2
+version: 2.0.3
 description: Cray HMS TRS Operator
 home: "https://github.com/Cray-HPE/hms-trs-operator-charts"
 sources:
@@ -31,6 +31,6 @@ sources:
 maintainers:
   - name: Hardware Management
     url: https://github.com/orgs/Cray-HPE/teams/hardware-management
-appVersion: "2.0.2"
+appVersion: "2.1.0"
 annotations:
   artifacthub.io/license: "MIT"

--- a/charts/v2.0/cray-hms-trs-operator/values.yaml
+++ b/charts/v2.0/cray-hms-trs-operator/values.yaml
@@ -22,7 +22,7 @@
 # OTHER DEALINGS IN THE SOFTWARE.
 #
 global:
-  appVersion: 2.0.2
+  appVersion: 2.1.0
 
 image:
   repository: artifactory.algol60.net/csm-docker/stable/hms-trs-operator

--- a/cray-hms-trs-operator.compatibility.yaml
+++ b/cray-hms-trs-operator.compatibility.yaml
@@ -35,6 +35,7 @@ chartVersionToApplicationVersion:
   "2.0.0": "2.0.0"
   "2.0.1": "2.0.1"
   "2.0.2": "2.0.2"
+  "2.0.3": "2.1.0"
 
 # Test results for combinations of Chart, Application, and CSM versions.  
 chartValidationLog: []


### PR DESCRIPTION

## Summary and Scope

Update the chart to use the latest app version. These changes include the app change to use v1beta2 of kafka.strimzi.io

## Issues and Related PRs

* Resolves CASMHMS-5525
* adopts changes from https://github.com/Cray-HPE/hms-trs-operator/pull/31

## Pull Request Checklist

- [x] Version number(s) incremented, if applicable
- [x] Copyrights updated
- [x] License file intact
- [x] Target branch correct
- [x] CHANGELOG.md updated
- [x] Testing is appropriate and complete, if applicable